### PR TITLE
feat(provider): send notifications/messages to whatsapp or as text SMS using Twilio

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ It provides a generic provider-based framework to add your own implementation or
 5. [FCM](https://firebase.google.com/docs/cloud-messaging) - It's one of the PushProvider for sending realtime push notifications to mobile applications as well as web applications.
 6. [Nodemailer](https://nodemailer.com/about/) - It's one of the EmailProvider for sending email messages.
 7. [Apple Push Notification service](https://developer.apple.com/library/archive/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/APNSOverview.html#//apple_ref/doc/uid/TP40008194-CH8-SW1) - It's one of the push notification providers that integrates notification service created by Apple Inc. that enables third party application developers to send notification data to applications installed on Apple devices.
+8. [Twilio SMS Service](https://www.twilio.com/docs/sms, https://www.twilio.com/docs/whatsapp) - Twilio is a modern communication API Used by developers for establishing communications. Twilio can be used for sending SMS or Whatapp notifications.
+   You can use one of these services or add your own implementation or integration using the same interfaces and attach it as a provider for that specific type.
 
 You can use one of these services or add your own implementation or integration using the same interfaces and attach it as a provider for that specific type.
 
@@ -281,7 +283,7 @@ If you wish to use any other service provider of your choice, you can create a p
 this.bind(NotificationBindings.EmailProvider).toProvider(MyOwnProvider);
 ```
 
-### SMS Notifications
+### SMS Notifications using AWS SNS
 
 This extension provides in-built support of AWS Simple Notification Service integration for sending SMS from the application. In order to use it, run `npm install aws-sdk`, and then bind the SnsProvider as below in `application.ts`.
 
@@ -341,7 +343,70 @@ If you wish to use any other service provider of your choice, you can create a p
 this.bind(NotificationBindings.SMSProvider).toProvider(MyOwnProvider);
 ```
 
-### Push Notifications With Pubnub
+
+### SMS / Whatsapp Notifications using Twilio
+
+This extension provides in-built support of Twilio integration for sending SMS / whatsapp notifications from the application. In order to use it, run `npm install twilio`, and then bind the TwilioProvider as below in application.ts.
+
+```ts
+import {
+  NotificationsComponent,
+  NotificationBindings,
+} from 'loopback4-notifications';
+import {
+  TwilioProvider
+} from 'loopback4-notification/twilio';
+....
+
+export class NotificationServiceApplication extends BootMixin(
+  ServiceMixin(RepositoryMixin(RestApplication)),
+) {
+  constructor(options: ApplicationConfig = {}) {
+    ....
+
+    this.component(NotificationsComponent);
+    this.bind(NotificationBindings.SMSProvider).toProvider(TwilioProvider);
+    ....
+  }
+}
+```
+
+There are some additional configurations needed in order to allow SNS to connect to Twilio. You need to add them as below. Make sure these are added before the provider binding.
+
+```ts
+import {
+  NotificationsComponent,
+  NotificationBindings,
+} from 'loopback4-notifications';
+import {
+  TwilioBindings,
+  TwilioProvider
+} from 'loopback4-notification/twilio';
+....
+
+export class NotificationServiceApplication extends BootMixin(
+  ServiceMixin(RepositoryMixin(RestApplication)),
+) {
+  constructor(options: ApplicationConfig = {}) {
+    ....
+
+    this.component(NotificationsComponent);
+    this.bind(TwilioBindings.Config).to({
+      accountSid: process.env.TWILIO_ACCOUNT_SID,
+      authToken: process.env.TWILIO_AUTH_TOKEN,
+      waFrom: process.env.TWILIO_WA_FROM,
+      smsFrom: process.env.TWILIO_SMS_FROM,
+      statusCallback:process.env.TWILIO_SMS_STATUS_CALLBACK,
+    });
+    this.bind(NotificationBindings.SMSProvider).toProvider(TwilioProvider);
+    ....
+  }
+}
+```
+
+All the configurations as specified by Twilio docs and console are supported in above TwilioBindings Config key. smsFrom could be messaging service id, twilio number or short code. waFrom could be whats app number or number associated to channel.
+
+### Push Notifications with Pubnub
 
 This extension provides in-built support of Pubnub integration for sending realtime push notifications from the application. In order to use it, run `npm install pubnub`, and then bind the PushProvider as below in `application.ts`.
 

--- a/README.md
+++ b/README.md
@@ -371,7 +371,7 @@ export class NotificationServiceApplication extends BootMixin(
 }
 ```
 
-There are some additional configurations needed in order to allow SNS to connect to Twilio. You need to add them as below. Make sure these are added before the provider binding.
+There are some additional configurations needed in order to connect to Twilio. You need to add them as below. Make sure these are added before the provider binding.
 
 ```ts
 import {
@@ -396,7 +396,8 @@ export class NotificationServiceApplication extends BootMixin(
       authToken: process.env.TWILIO_AUTH_TOKEN,
       waFrom: process.env.TWILIO_WA_FROM,
       smsFrom: process.env.TWILIO_SMS_FROM,
-      statusCallback:process.env.TWILIO_SMS_STATUS_CALLBACK,
+      waStatusCallback:process.env.TWILIO_WA_STATUS_CALLBACK,
+      smsStatusCallback:process.env.TWILIO_SMS_STATUS_CALLBACK,
     });
     this.bind(NotificationBindings.SMSProvider).toProvider(TwilioProvider);
     ....

--- a/package.json
+++ b/package.json
@@ -37,6 +37,10 @@
     "./sns": {
       "type": "./dist/providers/sms/sns/index.d.ts",
       "default": "./dist/providers/sms/sns/index.js"
+    },
+    "./twilio": {
+      "type": "./dist/providers/sms/twilio/index.d.ts",
+      "default": "./dist/providers/sms/twilio/index.js"
     }
   },
   "typesVersions": {
@@ -61,6 +65,9 @@
       ],
       "sns": [
         "./dist/providers/sms/sns/index.d.ts"
+      ],
+      "twilio": [
+        "./dist/providers/sms/twilio/index.d.ts"
       ]
     }
   },
@@ -140,7 +147,8 @@
     "simple-git": "^3.15.1",
     "socket.io-client": "^4.5.1",
     "source-map-support": "^0.5.21",
-    "typescript": "~4.9.4"
+    "typescript": "~4.9.4",
+    "twilio": "^3.82.0"
   },
   "overrides": {
     "@parse/node-apn": {

--- a/src/__tests__/mock-sdk.ts
+++ b/src/__tests__/mock-sdk.ts
@@ -1,5 +1,6 @@
 import AWS from 'aws-sdk';
 import Pubnub from 'pubnub';
+import twilio, {Twilio} from 'twilio';
 import {TwilioAuthConfig, TwilioMessage} from '../providers';
 import Mail = require('nodemailer/lib/mailer');
 import SMTPTransport = require('nodemailer/lib/smtp-transport');
@@ -41,6 +42,9 @@ export class MockPubnub {
 }
 
 export class MockTwilio {
-  constructor(config: TwilioAuthConfig) {}
+  twilioService: Twilio;
+  constructor(config: TwilioAuthConfig) {
+    this.twilioService = twilio(config.accountSid, config.authToken);
+  }
   async publish(message: TwilioMessage) {}
 }

--- a/src/__tests__/mock-sdk.ts
+++ b/src/__tests__/mock-sdk.ts
@@ -1,5 +1,6 @@
 import AWS from 'aws-sdk';
 import Pubnub from 'pubnub';
+import {TwilioAuthConfig, TwilioMessage} from '../providers';
 import Mail = require('nodemailer/lib/mailer');
 import SMTPTransport = require('nodemailer/lib/smtp-transport');
 
@@ -37,4 +38,9 @@ export class MockPubnub {
 
   grant(grantConfig: Pubnub.GrantParameters) {}
   async publish(publishConfig: Pubnub.PublishParameters) {}
+}
+
+export class MockTwilio {
+  constructor(config: TwilioAuthConfig) {}
+  async publish(message: TwilioMessage) {}
 }

--- a/src/__tests__/mock-sdk.ts
+++ b/src/__tests__/mock-sdk.ts
@@ -46,5 +46,7 @@ export class MockTwilio {
   constructor(config: TwilioAuthConfig) {
     this.twilioService = twilio(config.accountSid, config.authToken);
   }
+  //   sonarignore:start
   async publish(message: TwilioMessage) {}
+  //   sonarignore:end
 }

--- a/src/__tests__/mock-sdk.ts
+++ b/src/__tests__/mock-sdk.ts
@@ -47,6 +47,7 @@ export class MockTwilio {
     this.twilioService = twilio(config.accountSid, config.authToken);
   }
   //   sonarignore:start
+  // this is intensional
   async publish(message: TwilioMessage) {}
   //   sonarignore:end
 }

--- a/src/__tests__/mock-sdk.ts
+++ b/src/__tests__/mock-sdk.ts
@@ -46,8 +46,7 @@ export class MockTwilio {
   constructor(config: TwilioAuthConfig) {
     this.twilioService = twilio(config.accountSid, config.authToken);
   }
-  //   sonarignore:start
+  // sonarignore:start
   // this is intensional
   async publish(message: TwilioMessage) {}
-  //   sonarignore:end
-}
+  // sonarignore:end

--- a/src/__tests__/unit/twilio.provider.unit.ts
+++ b/src/__tests__/unit/twilio.provider.unit.ts
@@ -1,0 +1,130 @@
+import {Constructor} from '@loopback/core';
+import {expect, sinon} from '@loopback/testlab';
+import proxyquire from 'proxyquire';
+import {TwilioMessage, TwilioProvider} from '../../providers';
+
+describe('Twilio Service', () => {
+  const message: TwilioMessage = {
+    receiver: {
+      to: [],
+    },
+    body: 'test',
+    sentDate: new Date(),
+    type: 0,
+    subject: undefined,
+  };
+  const messageText: TwilioMessage = {
+    receiver: {
+      to: [
+        {
+          id: 'XXXXXXXXXXX',
+          type: 1,
+        },
+      ],
+    },
+    body: 'Test SMS Text Notification',
+    sentDate: new Date(),
+    type: 2,
+    subject: undefined,
+  };
+  const messageWhatsApp: TwilioMessage = {
+    receiver: {
+      to: [
+        {
+          id: 'XXXXXXXXXXX',
+          type: 0,
+        },
+      ],
+    },
+    body: 'Test Whatsapp Notification',
+    sentDate: new Date(),
+    type: 2,
+    subject: undefined,
+  };
+  const messageWAMedia: TwilioMessage = {
+    receiver: {
+      to: [
+        {
+          id: 'XXXXXXXXXXX',
+          type: 0,
+        },
+      ],
+    },
+    body: 'Test Whatsapp message with media',
+    mediaUrl: ['https://demo.twilio.com/owl.png'],
+    sentDate: new Date(),
+    type: 2,
+    subject: undefined,
+  };
+  const configration = {
+    accountSid: 'ACTSIDDUMMY',
+    authToken: 'AUTHDUMMY',
+    waFrom: '', //Ex. whatsapp:+XXXXXXXXXXX
+    smsFrom: '',
+    statusCallback: '',
+    opts: {dummy: true}, //Change dummy value to false when using unit test
+  };
+
+  let TwilioProviderMock: Constructor<TwilioProvider>;
+  beforeEach(setupMockTwilio);
+  describe('twilio configration addition', () => {
+    it('returns error message on passing reciever length as zero', async () => {
+      const twilioProvider = new TwilioProviderMock(configration).value();
+      const result = await twilioProvider
+        .publish(message)
+        .catch(err => err.message);
+      expect(result).which.eql('Message receiver not found in request');
+    });
+
+    it('returns error message when no twilio config', async () => {
+      try {
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        const twilioProvider = new TwilioProvider();
+      } catch (err) {
+        const result = err.message;
+        expect(result).which.eql('Twilio Config missing !');
+      }
+    });
+
+    it('returns the message (SMS text)', async () => {
+      const twilioProvider = new TwilioProviderMock(configration).value();
+      const result = twilioProvider.publish(messageText);
+      if (configration.opts?.dummy) {
+        expect(result).to.have.Promise();
+      } else {
+        await expect(result).to.be.fulfilled();
+      }
+    });
+
+    it('returns the message (Whatsapp)', async () => {
+      const twilioProvider = new TwilioProviderMock(configration).value();
+      const result = twilioProvider.publish(messageWAMedia);
+      if (configration.opts?.dummy) {
+        expect(result).to.have.Promise();
+      } else {
+        await expect(result).to.be.fulfilled();
+      }
+    });
+
+    it('returns the message (Whatsapp with Media)', async () => {
+      const twilioProvider = new TwilioProviderMock(configration).value();
+      const result = twilioProvider.publish(messageWhatsApp);
+      if (configration.opts?.dummy) {
+        expect(result).to.have.Promise();
+      } else {
+        await expect(result).to.be.fulfilled();
+      }
+    });
+  });
+
+  function setupMockTwilio() {
+    const mockTwilio = sinon.stub();
+    mockTwilio.prototype.publish = sinon.stub().returns(Promise.resolve());
+    TwilioProviderMock = proxyquire(
+      '../../providers/sms/twilio/twilio.provider',
+      {
+        'twilio.twilio': mockTwilio,
+      },
+    ).TwilioProvider;
+  }
+});

--- a/src/__tests__/unit/twilio.provider.unit.ts
+++ b/src/__tests__/unit/twilio.provider.unit.ts
@@ -27,6 +27,21 @@ describe('Twilio Service', () => {
     type: 2,
     subject: undefined,
   };
+  const messageTextMedia: TwilioMessage = {
+    receiver: {
+      to: [
+        {
+          id: 'XXXXXXXXXXX',
+          type: 1,
+        },
+      ],
+    },
+    body: 'Test SMS Notification with media',
+    mediaUrl: ['https://demo.twilio.com/owl.png'],
+    sentDate: new Date(),
+    type: 2,
+    subject: undefined,
+  };
   const messageWhatsApp: TwilioMessage = {
     receiver: {
       to: [
@@ -61,7 +76,6 @@ describe('Twilio Service', () => {
     authToken: 'AUTHDUMMY',
     waFrom: '', //Ex. whatsapp:+XXXXXXXXXXX
     smsFrom: '',
-    statusCallback: '',
     opts: {dummy: true}, //Change dummy value to false when using unit test
   };
 
@@ -96,9 +110,19 @@ describe('Twilio Service', () => {
       }
     });
 
+    it('returns the message (SMS with media)', async () => {
+      const twilioProvider = new TwilioProviderMock(configration).value();
+      const result = twilioProvider.publish(messageTextMedia);
+      if (configration.opts?.dummy) {
+        expect(result).to.have.Promise();
+      } else {
+        await expect(result).to.be.fulfilled();
+      }
+    });
+
     it('returns the message (Whatsapp)', async () => {
       const twilioProvider = new TwilioProviderMock(configration).value();
-      const result = twilioProvider.publish(messageWAMedia);
+      const result = twilioProvider.publish(messageWhatsApp);
       if (configration.opts?.dummy) {
         expect(result).to.have.Promise();
       } else {
@@ -108,7 +132,7 @@ describe('Twilio Service', () => {
 
     it('returns the message (Whatsapp with Media)', async () => {
       const twilioProvider = new TwilioProviderMock(configration).value();
-      const result = twilioProvider.publish(messageWhatsApp);
+      const result = twilioProvider.publish(messageWAMedia);
       if (configration.opts?.dummy) {
         expect(result).to.have.Promise();
       } else {

--- a/src/__tests__/unit/twilio.provider.unit.ts
+++ b/src/__tests__/unit/twilio.provider.unit.ts
@@ -92,8 +92,9 @@ describe('Twilio Service', () => {
 
     it('returns error message when no twilio config', async () => {
       try {
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
         // sonarignore:start
+        // this is intensional
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
         const twilioProvider = new TwilioProvider();
         // sonarignore:end
       } catch (err) {

--- a/src/__tests__/unit/twilio.provider.unit.ts
+++ b/src/__tests__/unit/twilio.provider.unit.ts
@@ -93,7 +93,9 @@ describe('Twilio Service', () => {
     it('returns error message when no twilio config', async () => {
       try {
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        //   sonarignore:start
         const twilioProvider = new TwilioProvider();
+        //   sonarignore:end
       } catch (err) {
         const result = err.message;
         expect(result).which.eql('Twilio Config missing !');

--- a/src/__tests__/unit/twilio.provider.unit.ts
+++ b/src/__tests__/unit/twilio.provider.unit.ts
@@ -92,11 +92,11 @@ describe('Twilio Service', () => {
 
     it('returns error message when no twilio config', async () => {
       try {
-        // sonarignore:start
+
         // NOSONAR
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
         const twilioProvider = new TwilioProvider();
-        // sonarignore:end
+
       } catch (err) {
         const result = err.message;
         expect(result).which.eql('Twilio Config missing !');

--- a/src/__tests__/unit/twilio.provider.unit.ts
+++ b/src/__tests__/unit/twilio.provider.unit.ts
@@ -93,9 +93,9 @@ describe('Twilio Service', () => {
     it('returns error message when no twilio config', async () => {
       try {
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        //   sonarignore:start
+        // sonarignore:start
         const twilioProvider = new TwilioProvider();
-        //   sonarignore:end
+        // sonarignore:end
       } catch (err) {
         const result = err.message;
         expect(result).which.eql('Twilio Config missing !');

--- a/src/__tests__/unit/twilio.provider.unit.ts
+++ b/src/__tests__/unit/twilio.provider.unit.ts
@@ -93,7 +93,7 @@ describe('Twilio Service', () => {
     it('returns error message when no twilio config', async () => {
       try {
         // sonarignore:start
-        // this is intensional
+        // NOSONAR
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
         const twilioProvider = new TwilioProvider();
         // sonarignore:end

--- a/src/providers/sms/index.ts
+++ b/src/providers/sms/index.ts
@@ -1,2 +1,3 @@
 export * from './sns';
+export * from './twilio';
 export * from './types';

--- a/src/providers/sms/twilio/index.ts
+++ b/src/providers/sms/twilio/index.ts
@@ -1,0 +1,3 @@
+export * from './keys';
+export * from './twilio.provider';
+export * from './types';

--- a/src/providers/sms/twilio/keys.ts
+++ b/src/providers/sms/twilio/keys.ts
@@ -1,0 +1,8 @@
+import {BindingKey} from '@loopback/core';
+import {TwilioAuthConfig} from '../twilio/types';
+
+export namespace TwilioBindings {
+  export const Config = BindingKey.create<TwilioAuthConfig | null>(
+    'sf.notification.config.twilio',
+  );
+}

--- a/src/providers/sms/twilio/twilio.provider.ts
+++ b/src/providers/sms/twilio/twilio.provider.ts
@@ -54,15 +54,19 @@ export class TwilioProvider implements Provider<TwilioNotification> {
           };
 
           // eslint-disable-next-line no-unused-expressions
-          !receiver.type &&
-            message.mediaUrl &&
-            (twilioMsgObj.mediaUrl = message.mediaUrl);
+          message.mediaUrl && (twilioMsgObj.mediaUrl = message.mediaUrl);
 
           // eslint-disable-next-line no-unused-expressions
           receiver.type &&
             receiver.type === TwilioSubscriberType.TextSMSUser &&
-            this.twilioConfig?.statusCallback &&
-            (twilioMsgObj.statusCallback = this.twilioConfig?.statusCallback);
+            this.twilioConfig?.smsStatusCallback &&
+            (twilioMsgObj.statusCallback =
+              this.twilioConfig?.smsStatusCallback);
+
+          // eslint-disable-next-line no-unused-expressions
+          !receiver.type &&
+            this.twilioConfig?.waStatusCallback &&
+            (twilioMsgObj.statusCallback = this.twilioConfig?.waStatusCallback);
 
           return this.twilioService.messages.create(twilioMsgObj);
         });

--- a/src/providers/sms/twilio/twilio.provider.ts
+++ b/src/providers/sms/twilio/twilio.provider.ts
@@ -1,0 +1,73 @@
+import {inject, Provider} from '@loopback/core';
+import {HttpErrors} from '@loopback/rest';
+import twilio, {Twilio} from 'twilio';
+import {TwilioBindings} from './keys';
+
+import {
+  TwilioAuthConfig,
+  TwilioCreateMessageParams,
+  TwilioMessage,
+  TwilioNotification,
+  TwilioSubscriberType,
+} from '../twilio/types';
+
+export class TwilioProvider implements Provider<TwilioNotification> {
+  twilioService: Twilio;
+  constructor(
+    @inject(TwilioBindings.Config, {
+      optional: true,
+    })
+    private readonly twilioConfig?: TwilioAuthConfig,
+  ) {
+    if (this.twilioConfig) {
+      this.twilioService = twilio(
+        this.twilioConfig.accountSid,
+        this.twilioConfig.authToken,
+      );
+    } else {
+      throw new HttpErrors.PreconditionFailed('Twilio Config missing !');
+    }
+  }
+
+  value() {
+    return {
+      publish: async (message: TwilioMessage) => {
+        if (message.receiver.to.length === 0) {
+          throw new HttpErrors.BadRequest(
+            'Message receiver not found in request',
+          );
+        }
+        const publishes = message.receiver.to.map(async receiver => {
+          const msg: string = message.body;
+          const twilioMsgObj: TwilioCreateMessageParams = {
+            body: msg,
+            from:
+              receiver.type &&
+              receiver.type === TwilioSubscriberType.TextSMSUser
+                ? String(this.twilioConfig?.smsFrom)
+                : String(this.twilioConfig?.waFrom),
+            to:
+              receiver.type &&
+              receiver.type === TwilioSubscriberType.TextSMSUser
+                ? `+${receiver.id}`
+                : `whatsapp:+${receiver.id}`,
+          };
+
+          // eslint-disable-next-line no-unused-expressions
+          !receiver.type &&
+            message.mediaUrl &&
+            (twilioMsgObj.mediaUrl = message.mediaUrl);
+
+          // eslint-disable-next-line no-unused-expressions
+          receiver.type &&
+            receiver.type === TwilioSubscriberType.TextSMSUser &&
+            this.twilioConfig?.statusCallback &&
+            (twilioMsgObj.statusCallback = this.twilioConfig?.statusCallback);
+
+          return this.twilioService.messages.create(twilioMsgObj);
+        });
+        await Promise.all(publishes);
+      },
+    };
+  }
+}

--- a/src/providers/sms/twilio/types.ts
+++ b/src/providers/sms/twilio/types.ts
@@ -1,0 +1,51 @@
+import {Twilio} from 'twilio';
+import {
+  SMSMessage,
+  SMSMessageOptions,
+  SMSNotification,
+  SMSReceiver,
+  SMSSubscriber,
+} from '../types';
+
+export interface TwilioNotification extends SMSNotification {
+  publish(message: TwilioMessage): Promise<void>;
+}
+
+export interface TwilioMessage extends SMSMessage {
+  receiver: TwilioReceiver;
+  mediaUrl?: Array<string>;
+}
+
+export interface TwilioReceiver extends SMSReceiver {
+  to: TwilioSubscriber[];
+}
+
+export interface TwilioSubscriber extends SMSSubscriber {
+  type: TwilioSubscriberType;
+}
+
+export const enum TwilioSubscriberType {
+  WhatsappUser = 0,
+  TextSMSUser = 1,
+}
+
+export const enum TwilioSMSType {
+  Whatapp = 'Whatapp',
+  TextSMS = 'TextSMS',
+}
+
+export interface TwilioAuthConfig extends Twilio.TwilioClientOptions {
+  authToken?: string;
+  waFrom?: String; //Whatsapp channel or phone number
+  smsFrom?: string; //From address of SMS twilio number or messaging SID
+  statusCallback?: string; //Status callback url to get messagte status
+  opts?: SMSMessageOptions;
+}
+
+export interface TwilioCreateMessageParams {
+  body: string;
+  from: string;
+  to: string;
+  mediaUrl?: Array<string>; //For whatsapp message with media
+  statusCallback?: string;
+}

--- a/src/providers/sms/twilio/types.ts
+++ b/src/providers/sms/twilio/types.ts
@@ -38,7 +38,8 @@ export interface TwilioAuthConfig extends Twilio.TwilioClientOptions {
   authToken?: string;
   waFrom?: String; //Whatsapp channel or phone number
   smsFrom?: string; //From address of SMS twilio number or messaging SID
-  statusCallback?: string; //Status callback url to get messagte status
+  waStatusCallback?: string; //Status callback url to get WA message status
+  smsStatusCallback?: string; //Status callback url to get SMS status
   opts?: SMSMessageOptions;
 }
 

--- a/src/providers/sms/twilio/types.ts
+++ b/src/providers/sms/twilio/types.ts
@@ -4,7 +4,7 @@ import {
   SMSMessageOptions,
   SMSNotification,
   SMSReceiver,
-  SMSSubscriber,
+  SMSSubscriber
 } from '../types';
 
 export interface TwilioNotification extends SMSNotification {
@@ -36,7 +36,7 @@ export const enum TwilioSMSType {
 
 export interface TwilioAuthConfig extends Twilio.TwilioClientOptions {
   authToken?: string;
-  waFrom?: String; //Whatsapp channel or phone number
+  waFrom?: string; //Whatsapp channel or phone number
   smsFrom?: string; //From address of SMS twilio number or messaging SID
   waStatusCallback?: string; //Status callback url to get WA message status
   smsStatusCallback?: string; //Status callback url to get SMS status

--- a/src/providers/sms/types.ts
+++ b/src/providers/sms/types.ts
@@ -1,4 +1,10 @@
-import {INotification, Message, Receiver, Subscriber} from '../../types';
+import {
+  INotification,
+  Message,
+  MessageOptions,
+  Receiver,
+  Subscriber,
+} from '../../types';
 
 export interface SMSNotification extends INotification {
   publish(message: SMSMessage): Promise<void>;
@@ -14,3 +20,4 @@ export interface SMSReceiver extends Receiver {
 }
 
 export interface SMSSubscriber extends Subscriber {}
+export interface SMSMessageOptions extends MessageOptions {}


### PR DESCRIPTION
send notifications/messages to whatsapp or as text SMS using Twilio

GH-88

## Description

Need to send SMS or whatsapp messages via Twilio.  (https://www.twilio.com/docs/sms, https://www.twilio.com/docs/whatsapp) - Twilio is a modern communication API Used by developers for establishing communications. Twilio can be used  as provider for sending SMS or Whatapp notifications

Fixes #88
This extension uses AWS SNS  as SMS provider.  SNS is not a good option for SMS as its delivery is unreliable. Please refer https://github.com/sourcefuse/loopback4-notifications/issues/88

## Type of change
FEAT - Added Provider
- [ ] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] Test A 
Unit test for twilio provider. Created twilio account and used sandbox to send SMS and whatsapp messages. Created sandbox whatsapp channel for whatsapp messages. Created messaging service SID to send SMS using twilio provider. We get  "accountSid", "authToken" as from twilio  for integration. Set required configurations in unit tests for the same and run test to send sms,  whatsapp message and whatsapp message with media. (src/__tests__/unit/twilio.provider.unit.ts)

## Checklist:

- [x] Performed a self-review of my own code
- [x] npm test passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the style guide
- [ ] API Documentation in code was updated
- [ ] Any dependent changes have been merged and published in downstream modules
